### PR TITLE
Respect HttpOnly cookie attribute

### DIFF
--- a/main.py
+++ b/main.py
@@ -144,6 +144,6 @@ def handle_request(path):
                             expires=cookie.expires,
                             path=cookie.path,
                             secure=cookie.secure,
-                            httponly=cookie.get_nonstandard_attr('HttpOnly'))
+                            httponly=cookie.has_nonstandard_attr('HttpOnly'))
 
     return response


### PR DESCRIPTION
HttpOnly is respected:

![no-false-positive](https://user-images.githubusercontent.com/5485798/71675718-52fe2680-2d76-11ea-8220-13de6cce06a5.gif)

reason this bug happened was `get_nonstandard_attr('HttpOnly')` returns `None` if it's set and `None` if it's not. When the cookie attribute is present it's value is literally `None`! The attribute is only present when the cookie should be HttpOnly