### PR TITLE
(tests,refactor) Use urllib3 rather than Requests in tests

### DIFF
--- a/requirements_test.in
+++ b/requirements_test.in
@@ -1,4 +1,3 @@
 -r requirements.in
 
 coverage==5.0.4
-requests==2.23.0

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -4,18 +4,14 @@
 #
 #    pip-compile --output-file requirements_test.txt requirements_test.in
 #
-certifi==2019.11.28       # via requests
-chardet==3.0.4            # via requests
 click==7.1.1              # via flask
 coverage==5.0.4
 flask==1.1.1
 gevent==1.4.0             # via gunicorn
 greenlet==0.4.15          # via gevent
 gunicorn[gevent]==19.9.0
-idna==2.9                 # via requests
 itsdangerous==1.1.0       # via flask
 jinja2==2.11.1            # via flask
 markupsafe==1.1.1         # via jinja2
-requests==2.23.0
 urllib3==1.25.8
 werkzeug==1.0.0           # via flask


### PR DESCRIPTION
This has three benefits:

- Doesn't use the automatic connection-reuse that Requests does. From understanding of PaaS, connections from the router to applications/routing services are never re-used. So this makes the requests in the tests behave a touch more like real requests in PaaS.

  (Note: this is opposed to connections from the outside world, orapplications, to the ALB in front of the router, which I think _are_reused)

- Stronger evidence that the tests don't pass because of a requirement in requirements_test.in. From this commit, it's only `coverage`, which itself has no extra dependencies.

- Don't have to do the hack/workaround to get Requests to stream a non-chunked request, where you have to prepare the request and delete
 the `transfer-encoding: chunked` header