### PR TITLE
Add caching to get route config

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,4 +1,5 @@
 flask==1.1.1
+Flask-Caching==2.0.2
 gunicorn==20.1.0
 gevent==1.5.0
 urllib3==1.26.5

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,8 @@ click==7.1.1
     # via flask
 flask==1.1.1
     # via -r requirements.in
+Flask-Caching==2.0.2
+    # via -r requirements.in
 gevent==1.5.0
     # via -r requirements.in
 greenlet==0.4.15

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -10,6 +10,8 @@ coverage==5.0.4
     # via -r requirements_test.in
 flask==1.1.1
     # via -r requirements.in
+Flask-Caching==2.0.2
+    # via -r requirements.in
 gevent==1.4.0
     # via gunicorn
 greenlet==0.4.15


### PR DESCRIPTION
- Adds Flask-Caching library and manually caches result of getting config from s3 bucket.

Not sure how to test this without patching the cache and can't get patch working because filter is started as a separate process. Don't know if it's a blocker.

Also have no idea what a reasonable timeout is for something like this. Any opinions welcome...